### PR TITLE
Run tests on all platforms

### DIFF
--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -40,58 +40,6 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
-  run_tests:
-    name: Run tests ${{ matrix.builder.target }}
-    runs-on: ${{ matrix.builder.runner }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        builder: [
-          {
-            name: windows,
-            target: x86_64-pc-windows-gnu,
-            runner: windows-2019
-          },
-          {
-            name: windows,
-            target: x86_64-pc-windows-msvc,
-            runner: windows-2019
-          },
-          {
-            name: mac,
-            target: x86_64-apple-darwin,
-            runner: macos-12
-          },
-          {
-            name: mac,
-            target: aarch64-apple-darwin,
-            runner: macos-14 # ARM
-          },
-          {
-            name: linux,
-            target: x86_64-unknown-linux-musl,
-            runner: ubuntu-20.04
-          },
-          {
-            name: linux,
-            target: x86_64-unknown-linux-gnu,
-            runner: ubuntu-20.04
-          }
-        ]
-
-    steps:
-      - name: Checkout reposistory
-        uses: actions/checkout@v4
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.builder.target }}
-
-      - name: Run tests
-        run: cargo test --workspace --target ${{ matrix.builder.target }}
-
   msrv:
     runs-on: ubuntu-latest
     steps:
@@ -105,10 +53,9 @@ jobs:
         run: cargo hack check --rust-version --workspace --all-targets --ignore-private
 
 
-  release:
-    name: release artifact for ${{ matrix.builder.target }}
+  test_and_release:
+    name: Run tests and release artifact for ${{ matrix.builder.target }}
     runs-on: ${{ matrix.builder.runner }}
-    needs: [run_tests, msrv]
 
     strategy:
       fail-fast: false
@@ -155,8 +102,11 @@ jobs:
         with:
           targets: ${{ matrix.builder.target }}
 
+      - name: Run tests
+        run: cargo test --workspace --target ${{ matrix.builder.target }}
+
       - name: Build cli
-        run: cargo build --release --target ${{ matrix.builder.target }}
+        run: cargo build --release --bins --target ${{ matrix.builder.target }}
 
       - name: Move files for packaging (unix)
         if: matrix.builder.name == 'linux' || matrix.builder.name == 'mac'
@@ -195,7 +145,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    needs: [run_tests, msrv]
+    needs: [test_and_release, msrv]
 
     steps:
       - name: Checkout reposistory

--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -66,7 +66,7 @@ jobs:
           {
             name: mac,
             target: aarch64-apple-darwin,
-            runner: macos-12
+            runner: macos-14 # ARM
           },
           {
             name: linux,
@@ -132,7 +132,7 @@ jobs:
           {
             name: mac,
             target: aarch64-apple-darwin,
-            runner: macos-12
+            runner: macos-14 # ARM
           },
           {
             name: linux,

--- a/.github/workflows/publish_crate.yml
+++ b/.github/workflows/publish_crate.yml
@@ -41,21 +41,56 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
   run_tests:
-    name: Run tests
-    runs-on: ubuntu-latest
+    name: Run tests ${{ matrix.builder.target }}
+    runs-on: ${{ matrix.builder.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        builder: [
+          {
+            name: windows,
+            target: x86_64-pc-windows-gnu,
+            runner: windows-2019
+          },
+          {
+            name: windows,
+            target: x86_64-pc-windows-msvc,
+            runner: windows-2019
+          },
+          {
+            name: mac,
+            target: x86_64-apple-darwin,
+            runner: macos-12
+          },
+          {
+            name: mac,
+            target: aarch64-apple-darwin,
+            runner: macos-12
+          },
+          {
+            name: linux,
+            target: x86_64-unknown-linux-musl,
+            runner: ubuntu-20.04
+          },
+          {
+            name: linux,
+            target: x86_64-unknown-linux-gnu,
+            runner: ubuntu-20.04
+          }
+        ]
 
     steps:
       - name: Checkout reposistory
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
+          targets: ${{ matrix.builder.target }}
 
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --target ${{ matrix.builder.target }}
 
   msrv:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Produce an error if the user specifies an empty conditional
   inclusion/exclusion for any entry.
+- Tests now strip the `\r` character from the expected files before compaing
+  them.
+  - This is done to normalize the tests files accross all platforms, including
+    the ones where git may add `\r` characters when cloning the repository
+    (like Windows).
+- Github Actions:
+  - Change CI to run tests on all platforms we generate builds artifacts for.
+  - Use the ARM Mac Github runner to build and test the ARM Mac builds.
 
 ## [0.2.5] - 2024-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Github Actions:
   - Change CI to run tests on all platforms we generate builds artifacts for.
   - Use the ARM Mac Github runner to build and test the ARM Mac builds.
+  - Merge `run_tests` and `release` jobs to try to improve CI times.
 
 ## [0.2.5] - 2024-07-17
 

--- a/slinky/tests/integration_test.rs
+++ b/slinky/tests/integration_test.rs
@@ -25,19 +25,19 @@ fn compare_multiline_strings(left: &str, right: &str) {
             (Some(l), Some(r)) => {
                 if l != r {
                     println!("  Different lines:");
-                    println!("    left:  {}", l);
-                    println!("    right: {}", r);
+                    println!("    left:  {:?}", l);
+                    println!("    right: {:?}", r);
                     println!();
                 }
             }
             (Some(l), None) => {
                 println!("  Only one line:");
-                println!("    left:  {}", l);
+                println!("    left:  {:?}", l);
                 println!();
             }
             (None, Some(r)) => {
                 println!("  Only one line:");
-                println!("    right: {}", r);
+                println!("    right: {:?}", r);
                 println!();
             }
             (None, None) => break,

--- a/slinky/tests/integration_test.rs
+++ b/slinky/tests/integration_test.rs
@@ -7,8 +7,20 @@ use std::path::{Path, PathBuf};
 use rstest::rstest;
 use slinky::{RuntimeSettings, ScriptExporter, ScriptImporter, SlinkyError};
 
-fn compare_multiline_strings(left: &str, right: &str) {
-    if left == right {
+fn compare_multiline_strings(expected: &str, generated: &str) {
+    // We manually strip the CARRIAGE RETURN (`\r`/`U+000D`) character only from
+    // expected because it may get included into the test files when cloning this
+    // repository on Windows with a git configured with its default settings.
+    //
+    // Rust never writes a `\r` character using the `writeln!` macro, so it is
+    // not like this character would get added automatically on Windows builds
+    // of slinky, so the simplest solution is to just strip this character from
+    // `expected`.
+    //
+    // What can go wrong?
+    let expected_cleaned = expected.replace('\r', "");
+
+    if expected_cleaned == generated {
         return;
     }
 
@@ -16,28 +28,28 @@ fn compare_multiline_strings(left: &str, right: &str) {
     println!("Not equal strings :c");
     println!();
 
-    let mut left_splitted = left.split("\n");
-    let mut right_splitted = right.split("\n");
+    let mut expected_splitted = expected_cleaned.split("\n");
+    let mut generated_splitted = generated.split("\n");
 
     // https://stackoverflow.com/a/38168890/6292472
     loop {
-        match (left_splitted.next(), right_splitted.next()) {
+        match (expected_splitted.next(), generated_splitted.next()) {
             (Some(l), Some(r)) => {
                 if l != r {
                     println!("  Different lines:");
-                    println!("    left:  {:?}", l);
-                    println!("    right: {:?}", r);
+                    println!("    expected:  {:?}", l);
+                    println!("    generated: {:?}", r);
                     println!();
                 }
             }
             (Some(l), None) => {
                 println!("  Only one line:");
-                println!("    left:  {:?}", l);
+                println!("    expected:  {:?}", l);
                 println!();
             }
             (None, Some(r)) => {
                 println!("  Only one line:");
-                println!("    right: {:?}", r);
+                println!("    generated: {:?}", r);
                 println!();
             }
             (None, None) => break,
@@ -48,7 +60,7 @@ fn compare_multiline_strings(left: &str, right: &str) {
     println!("full inequality:");
     println!();
 
-    assert_eq!(left, right);
+    assert_eq!(expected_cleaned, generated);
 }
 
 fn create_runtime_settings() -> RuntimeSettings {


### PR DESCRIPTION
Tests now do run on all the platforms we generate builds artifacts for.

Main changes include actually using ARM Macs on CI to build and test ARM builds and strip the `\r` from the test files because git may add them on Windows, making the tests fail when testing them on Windows.

